### PR TITLE
Adding option to exclude certain folders on scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ We will watch the change of package.json, and auto add and remove module.
 "js-import.filesToScan": "**/*.{jsx,js,tsx,ts}"
 
 //Glob for files to exclude from watch and scan, e.g **/.meteor/**. Defaults to nothing
-"js-import.excludeFilesToScan": "**/.meteor/**"
+"js-import.excludeFilesToScan": ""
 
 //suffix of plainFiles. Defaults to css,less,sass
 //When import file with these suffixes, the import statement only has 'import' and 'model-name' like 'import 'xxx.less'.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ We will watch the change of package.json, and auto add and remove module.
 //Glob for files to watch and scan, e.g ./src/** ./src/app/**/*.js. Defaults to **/*.{jsx,js,ts,tsx}
 "js-import.filesToScan": "**/*.{jsx,js,tsx,ts}"
 
+//Glob for files to exclude from watch and scan, e.g **/.meteor/**. Defaults to nothing
+"js-import.excludeFilesToScan": "**/.meteor/**"
+
 //suffix of plainFiles. Defaults to css,less,sass
 //When import file with these suffixes, the import statement only has 'import' and 'model-name' like 'import 'xxx.less'.
 //if you use css modules, you can remove css,less,sass in here, see config js-import.plainFileSuffixWithDefaultMember

--- a/package.json
+++ b/package.json
@@ -2,13 +2,15 @@
     "name": "vscode-js-import",
     "displayName": "vscode-js-import",
     "description": "Intelligent and fast import extension for js in vscode, support import position option and adding import to existing import statement.",
-    "version": "0.15.2",
+    "version": "0.15.3",
     "publisher": "wangtao0101",
     "repository": {
         "type": "git",
         "url": "https://github.com/wangtao0101/vscode-js-import.git"
     },
-    "keywords": ["multi-root ready"],
+    "keywords": [
+        "multi-root ready"
+    ],
     "engines": {
         "vscode": "^1.17.0"
     },
@@ -55,6 +57,12 @@
                     "type": "string",
                     "default": "**/*.{jsx,js,tsx,ts}",
                     "description": "Glob for files to watch and scan, e.g ./src/** ./src/app/**/*.js. Defaults to **/*.{jsx,js,ts}",
+                    "scope": "resource"
+                },
+                "js-import.excludeFilesToScan": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Glob for files to exclude from watch and scan, e.g **/.meteor/**. Defaults to nothing",
                     "scope": "resource"
                 },
                 "js-import.plainFileSuffix": {

--- a/src/rootCache.ts
+++ b/src/rootCache.ts
@@ -17,15 +17,18 @@ export default class RootCache {
         defaultMemberPlainFiles: [],
         plainFilesGlob: '',
         filesToScan: '',
+        excludeFilesToScan: '',
     }
 
     constructor(workspaceFolder: WorkspaceFolder) {
         this.workspaceFolder = workspaceFolder;
         const filesToScan = vscode.workspace.getConfiguration('js-import', this.workspaceFolder.uri).get<string>('filesToScan');
+        const excludeFilesToScan = vscode.workspace.getConfiguration('js-import', this.workspaceFolder.uri).get<string>('excludeFilesToScan');
         const plainFileSuffix = vscode.workspace.getConfiguration('js-import', this.workspaceFolder.uri).get<string>('plainFileSuffix');
         const plainFileSuffixWithDefaultMember = vscode.workspace.getConfiguration('js-import', this.workspaceFolder.uri).get<string>('plainFileSuffixWithDefaultMember');
 
         this.options.filesToScan = filesToScan;
+        this.options.excludeFilesToScan = `{**/node_modules/**${excludeFilesToScan ? ','+excludeFilesToScan : ""}}`;
         this.options.emptyMemberPlainFiles = plainFileSuffix.split(',').map((x) => x.trim());
         this.options.defaultMemberPlainFiles = plainFileSuffixWithDefaultMember.split(',').map((x) => x.trim());
         this.options.plainFilesGlob = `**/*.{${this.options.emptyMemberPlainFiles.concat(this.options.defaultMemberPlainFiles).join(',')}}`;

--- a/src/rootScanner.ts
+++ b/src/rootScanner.ts
@@ -34,6 +34,7 @@ export interface RootOptions {
     defaultMemberPlainFiles : Array<string>,
     plainFilesGlob: string,
     filesToScan: string;
+    excludeFilesToScan: string;
 }
 
 export default class RootScanner {
@@ -54,7 +55,7 @@ export default class RootScanner {
     public scanAllImport() {
         const relativePattern = new RelativePattern(this.workspaceFolder, this.options.filesToScan);
         // TODO: filter file not in src
-        vscode.workspace.findFiles(relativePattern, '{**/node_modules/**}', 99999)
+        vscode.workspace.findFiles(relativePattern, this.options.excludeFilesToScan, 99999)
             .then((files) => this.processFiles(files));
         this.findModulesInPackageJson();
         this.processPlainFiles();
@@ -76,7 +77,7 @@ export default class RootScanner {
 
     private processPlainFiles() {
         const relativePattern = new vscode.RelativePattern(this.workspaceFolder, this.options.plainFilesGlob);
-        vscode.workspace.findFiles(relativePattern, '{**/node_modules/**}', 99999)
+        vscode.workspace.findFiles(relativePattern, this.options.excludeFilesToScan, 99999)
         .then((files) => {
             files.filter((f) => {
                 return f.fsPath.indexOf('node_modules') === -1

--- a/test/testRoot/.vscode/settings.json
+++ b/test/testRoot/.vscode/settings.json
@@ -11,6 +11,7 @@
         "helpalias": "src/package/"
     },
     "js-import.filesToScan": "**/*.{jsx,tsx,ts,js,vue}",
+    "js-import.excludeFilesToScan": "",
     "js-import.commaDangleImport": "never",
     "js-import.quote": "singlequote",
     "js-import.codeCompletionAction": false,


### PR DESCRIPTION
The motivation for this pull request is working with meteor.js framework, who uses certain files at .meteor folder that when scanned pollute the import window.

Solves issue: #17